### PR TITLE
[platform-none] fix VM names in restart function

### DIFF
--- a/platform_none/install.sh
+++ b/platform_none/install.sh
@@ -210,8 +210,8 @@ function restartWorkers() {
 }
 
 function restartControlPlaneNodes() {
-    govc vm.power -off=true $INFRA_NAME-master*
-    govc vm.power -on=true $INFRA_NAME-master*
+    govc vm.power -off=true $INFRA_NAME-cp*
+    govc vm.power -on=true $INFRA_NAME-cp*
 }
 
 function approveCSRs() {


### PR DESCRIPTION
This commit fixes the restartControlPlaneNodes() function with the
correct name matching pattern, following the same naming convention for
the control plane nodes used in the startControlPlaneNodes() function.