### PR TITLE
Formatting fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,18 @@ curl -O https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_
 1. Run `terraform init` if you are doing this for the first time
 2. Copy your install-config.yaml into `inst`
 3. If you are creating a OVN hybrid cluster:
-   a. Run `openshift-install create manifests --dir inst`
-   b. Copy your `cluster-network-03-config.yml` into `inst/manifests/
+   1. Run `openshift-install create manifests --dir inst`
+   2. Copy your `cluster-network-03-config.yml` into `inst/manifests/`
 4. Create ignition files and place them in `inst`
-   a. Run `openshift-install create ignition-configs --dir inst`
+   1. Run `openshift-install create ignition-configs --dir inst`
 5. Copy `terraform.tfvars.example` to `terraform.tfvars`
 6. Update `terraform.tfvars` with details relevant to your installation
-   a. OpenShift developers can start with this [example](https://gist.githubusercontent.com/rvanderp3/ef13bd8f7432871bee4f38a60bb3b5ed/raw/d0a6acb137f500876dd22901ac6e5cbcd495aaf9/terraform.tfvars)
+   1. OpenShift developers can start with this [example](https://gist.githubusercontent.com/rvanderp3/ef13bd8f7432871bee4f38a60bb3b5ed/raw/d0a6acb137f500876dd22901ac6e5cbcd495aaf9/terraform.tfvars)
 7. Run `terraform apply -auto-approve`
 8. Run `openshift-install wait-for bootstrap-complete --dir inst`
 9. Run `openshift-install wait-for install-complete --dir inst`
-10. While waiting for the install to be complete, execute
-    `oc adm certificate approve ``oc get csr -o=jsonpath='{.items[*].metadata.name}'```
+10. While waiting for the install to be complete, execute:
+    ``oc adm certificate approve `oc get csr -o=jsonpath='{.items[*].metadata.name}'` ``
     until all workers have joined the cluster.
 
 When finished, run `terraform destroy -auto-approve`.


### PR DESCRIPTION
A double backtick is needed to enclose items that have backticks